### PR TITLE
Updates to Zephyr I2C Driver

### DIFF
--- a/fprime-zephyr/Drv/ZephyrI2CDriver/ZephyrI2CDriver.cpp
+++ b/fprime-zephyr/Drv/ZephyrI2CDriver/ZephyrI2CDriver.cpp
@@ -24,7 +24,7 @@ namespace Zephyr {
     ZephyrI2CDriver ::~ZephyrI2CDriver() {}
 
     //  I2CConfiguration configuration ? 
-    Os::File::Status ZephyrI2CDriver::open(struct i2c_dt_spec i2c_device){
+    Os::File::Status ZephyrI2CDriver::open(const struct i2c_dt_spec i2c_device){
       this->m_device = i2c_device;
       if(!i2c_is_ready_dt(&this->m_device)){
         return Os::File::Status::NOT_OPENED;
@@ -37,7 +37,7 @@ namespace Zephyr {
     // Handler implementations for typed input ports
     // ----------------------------------------------------------------------
 
-    Drv::I2cStatus ZephyrI2CDriver ::i2cread_handler(FwIndexType portNum, U16 addr,
+    Drv::I2cStatus ZephyrI2CDriver ::read_handler(FwIndexType portNum, U32 addr,
                                                   Fw::Buffer &serBuffer) {
       int status = i2c_read_dt(&this->m_device, serBuffer.getData(), serBuffer.getSize()); 
       if(status != 0){
@@ -46,11 +46,20 @@ namespace Zephyr {
       return Drv::I2cStatus::I2C_OK;
     }
 
-    Drv::I2cStatus ZephyrI2CDriver ::i2cwrite_handler(FwIndexType portNum, U16 addr,
+    Drv::I2cStatus ZephyrI2CDriver ::write_handler(FwIndexType portNum, U32 addr,
                                                   Fw::Buffer &serBuffer) {
       int status = i2c_write_dt(&this->m_device, serBuffer.getData(), serBuffer.getSize()); 
       if(status != 0){
         printk("I2C write error\n");
+      }
+      return Drv::I2cStatus::I2C_OK;
+    }
+
+    Drv::I2cStatus ZephyrI2CDriver ::writeRead_handler(FwIndexType portNum, U32 addr,
+      Fw::Buffer &writeBuffer, Fw::Buffer &readBuffer) {
+      int status = i2c_write_read_dt(&this->m_device, writeBuffer.getData(), writeBuffer.getSize(), readBuffer.getData(), readBuffer.getSize()); 
+      if(status != 0){
+          printk("I2C write error\n");
       }
       return Drv::I2cStatus::I2C_OK;
     }

--- a/fprime-zephyr/Drv/ZephyrI2CDriver/ZephyrI2CDriver.hpp
+++ b/fprime-zephyr/Drv/ZephyrI2CDriver/ZephyrI2CDriver.hpp
@@ -39,22 +39,24 @@ namespace Zephyr {
         // Handler implementations for typed input ports
         // ----------------------------------------------------------------------
 
-        //! Handler implementation for read
-        //!
-        //! Port for guarded synchronous reading from I2C
-        Drv::I2cStatus i2cread_handler(FwIndexType portNum,  //!< The port number
-                    U16 addr,             //!< I2C slave device address
-                    Fw::Buffer &serBuffer //!< Buffer with data to read/write to/from
-        );
+         //! Handler implementation for write
+    //!
+    Drv::I2cStatus write_handler(const FwIndexType portNum, /*!< The port number*/
+      U32 addr,
+      Fw::Buffer& serBuffer) override;
 
-        //! Handler implementation for write
-        //!
-        //! Port for guarded synchronous writing to I2C
-        Drv::I2cStatus i2cwrite_handler(
-            FwIndexType portNum,  //!< The port number
-            U16 addr,             //!< I2C slave device address
-            Fw::Buffer &serBuffer //!< Buffer with data to read/write to/from
-        );
+    //! Handler implementation for read
+    //!
+    Drv::I2cStatus read_handler(const FwIndexType portNum, /*!< The port number*/
+        U32 addr,
+        Fw::Buffer& serBuffer) override;
+
+    //! Handler implementation for writeRead
+    //!
+    Drv::I2cStatus writeRead_handler(const FwIndexType portNum, /*!< The port number*/
+          U32 addr,
+          Fw::Buffer& writeBuffer,
+          Fw::Buffer& readBuffer) override;
 
         struct i2c_dt_spec m_device; // has a pointer to I2C bus, and target address (U16)
   };


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| n/a |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

<!-- A description of the changes contained in the PR. -->
Updating Zephyr I2C types, read and write handlers. 

## Rationale

Wanting to have the [`fprime-zephyr-reference` ](https://github.com/fprime-community/fprime-zephyr-reference) work with the [`fprime-sensors`](https://github.com/fprime-community/fprime-sensors) library. 

## Testing/Review Recommendations

n/a

## Future Work

Still does not work. PR sent in for work across forks. 
Next, to get the SPI driver working. 

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

<!-- If AI was used, please describe how it was utilized (e.g., code generation, documentation, testing, debugging assistance, etc.). -->
Assisted in finding specific git commands. 