### PR TITLE
Add LoRa Radio Manager

### DIFF
--- a/default/zephyr-config/CMakeLists.txt
+++ b/default/zephyr-config/CMakeLists.txt
@@ -1,0 +1,10 @@
+####
+# default/config/CMakeLists.txt:
+#
+# Sets a list of source files for cmake to process as part of autocoding.
+####
+register_fprime_config(
+    HEADERS
+        "${CMAKE_CURRENT_LIST_DIR}/LoRaCfg.hpp"
+    INTERFACE
+)

--- a/default/zephyr-config/LoRaCfg.hpp
+++ b/default/zephyr-config/LoRaCfg.hpp
@@ -1,0 +1,12 @@
+#ifndef LORA_CFG_HPP
+#define LORA_CFG_HPP
+#include <zephyr/drivers/lora.h>
+#include <Fw/FPrimeBasicTypes.hpp>
+namespace LoRaConfig {
+const U32 FREQUENCY = 915000000;               // 437400000; //!< LoRa frequency in Hz
+lora_signal_bandwidth BANDWIDTH = BW_125_KHZ;  //!< LoRa bandwidth
+const I8 TX_POWER = 14;                        //!< LoRa transmission power in dBm
+const U16 PREAMBLE_LENGTH = 8;                 //!< LoRa preamble length
+U8 HEADER[] = {0, 0, 0, 0};                    //!< LoRa header (not used)
+}  // namespace LoRaConfig
+#endif  // LORA_CFG_HPP

--- a/fprime-zephyr.cmake
+++ b/fprime-zephyr.cmake
@@ -1,6 +1,8 @@
+add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/default/zephyr-config")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/fprime-zephyr/Os")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/fprime-zephyr/Drv/ZephyrUartDriver")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/fprime-zephyr/Drv/ZephyrGpioDriver")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/fprime-zephyr/Drv/ZephyrRateDriver")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/fprime-zephyr/Drv/ZephyrI2CDriver")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/fprime-zephyr/Drv/ZephyrSpiDriver")
+add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/fprime-zephyr/Drv/LoRa")

--- a/fprime-zephyr/Drv/LoRa/CMakeLists.txt
+++ b/fprime-zephyr/Drv/LoRa/CMakeLists.txt
@@ -1,0 +1,36 @@
+####
+# F Prime CMakeLists.txt:
+#
+# SOURCES: list of source files (to be compiled)
+# AUTOCODER_INPUTS: list of files to be passed to the autocoders
+# DEPENDS: list of libraries that this module depends on
+#
+# More information in the F´ CMake API documentation:
+# https://fprime.jpl.nasa.gov/latest/docs/reference/api/cmake/API/
+#
+####
+
+# Module names are derived from the path from the nearest project/library/framework
+# root when not specifically overridden by the developer. i.e. The module defined by
+# `Ref/SignalGen/CMakeLists.txt` will be named `Ref_SignalGen`.
+
+register_fprime_library(
+    AUTOCODER_INPUTS
+        "${CMAKE_CURRENT_LIST_DIR}/LoRa.fpp"
+    SOURCES
+        "${CMAKE_CURRENT_LIST_DIR}/LoRa.cpp"
+   DEPENDS
+       default_zephyr-config
+)
+
+### Unit Tests ###
+# register_fprime_ut(
+#     AUTOCODER_INPUTS
+#         "${CMAKE_CURRENT_LIST_DIR}/LoRa.fpp"
+#     SOURCES
+#         "${CMAKE_CURRENT_LIST_DIR}/test/ut/LoRaTestMain.cpp"
+#         "${CMAKE_CURRENT_LIST_DIR}/test/ut/LoRaTester.cpp"
+#     DEPENDS
+#         STest # For rules-based testing
+#     UT_AUTO_HELPERS
+# )

--- a/fprime-zephyr/Drv/LoRa/LoRa.cpp
+++ b/fprime-zephyr/Drv/LoRa/LoRa.cpp
@@ -1,0 +1,162 @@
+// ======================================================================
+// \title  LoRa.cpp
+// \author lestarch
+// \brief  cpp file for LoRa component implementation class
+// ======================================================================
+
+#include "fprime-zephyr/Drv/LoRa/LoRa.hpp"
+#include "Fw/Logger/Logger.hpp"
+#include "zephyr-config/LoRaCfg.hpp"
+
+namespace Zephyr {
+
+// Base configuration for the LoRa modem
+struct lora_modem_config BASE_CONFIG = {
+    .frequency = LoRaConfig::FREQUENCY,
+    .bandwidth = BW_125_KHZ,
+    .datarate = SF_8,
+    .coding_rate = CR_4_5,
+    .preamble_len = LoRaConfig::PREAMBLE_LENGTH,
+    .tx_power = LoRaConfig::TX_POWER,
+    .tx = false,
+    .iq_inverted = false,
+    .public_network = false,
+};
+
+// ----------------------------------------------------------------------
+// Component construction and destruction
+// ----------------------------------------------------------------------
+
+void LoRa::receiveCallback(const struct device* dev, U8* data, U16 size, I16 rssi, I8 snr, void* user_data) {
+    Zephyr::LoRa* lora_component = static_cast<Zephyr::LoRa*>(user_data);
+    FW_ASSERT(lora_component != nullptr);
+    lora_component->receive(data, size, rssi, snr);
+}
+
+LoRa ::LoRa(const char* const compName) : LoRaComponentBase(compName) {}
+
+LoRa ::~LoRa() {}
+
+LoRa::Status LoRa ::start(const struct device* lora_device) {
+    if (!device_is_ready(lora_device)) {
+        return NOT_READY;
+    }
+    this->m_lora_device = lora_device;
+
+    LoRa::Status config_status = this->enableRx();
+    if (config_status != Status::SUCCESS) {
+        Fw::Logger::log("Failed to enable Rx");
+        return LoRa::Status::ERROR;
+    }
+    Fw::Success status = Fw::Success::SUCCESS;
+    this->comStatusOut_out(0, status);
+    return Status::SUCCESS;
+}
+
+LoRa::Status LoRa ::enableTx() {
+    Fw::ParamValid isValid = Fw::ParamValid::INVALID;
+    const LoRaDataRate data_rate = this->paramGet_DATA_RATE(isValid);
+    FW_ASSERT(isValid != Fw::ParamValid::VALID, static_cast<FwAssertArgType>(isValid));
+    const LoRaCodingRate coding_rate = this->paramGet_CODING_RATE(isValid);
+    FW_ASSERT(isValid != Fw::ParamValid::VALID, static_cast<FwAssertArgType>(isValid));
+
+    // Disable async receive while in TX mode
+    int status = lora_recv_async(this->m_lora_device, NULL, NULL);
+    if (status == 0) {
+        // Update BASE_CONFIG in-place to save on stack space
+        BASE_CONFIG.tx = true;
+        BASE_CONFIG.datarate = static_cast<enum lora_datarate>(data_rate.e);
+        BASE_CONFIG.coding_rate = static_cast<enum lora_coding_rate>(coding_rate.e);
+        status = lora_config(this->m_lora_device, &BASE_CONFIG);
+    }
+    return (status < 0) ? Status::ERROR : Status::SUCCESS;
+}
+
+LoRa::Status LoRa ::enableRx() {
+    Fw::ParamValid isValid = Fw::ParamValid::INVALID;
+    const LoRaDataRate data_rate = this->paramGet_DATA_RATE(isValid);
+    FW_ASSERT(isValid != Fw::ParamValid::INVALID, static_cast<FwAssertArgType>(isValid));
+    const LoRaCodingRate coding_rate = this->paramGet_CODING_RATE(isValid);
+    FW_ASSERT(isValid != Fw::ParamValid::INVALID, static_cast<FwAssertArgType>(isValid));
+
+    // Update BASE_CONFIG in-place to save on stack space
+    BASE_CONFIG.tx = false;
+    BASE_CONFIG.datarate = static_cast<enum lora_datarate>(data_rate.e);
+    BASE_CONFIG.coding_rate = static_cast<enum lora_coding_rate>(coding_rate.e);
+    int status = lora_config(this->m_lora_device, &BASE_CONFIG);
+    if (status == 0) {
+        status = lora_recv_async(this->m_lora_device, LoRa::receiveCallback, this);
+    }
+    return (status < 0) ? Status::ERROR : Status::SUCCESS;
+}
+
+// ----------------------------------------------------------------------
+// Handler implementations for typed input ports
+// ----------------------------------------------------------------------
+
+void LoRa ::dataIn_handler(FwIndexType portNum, Fw::Buffer& data, const ComCfg::FrameContext& context) {
+    Os::ScopeLock lock(this->m_mutex);
+    FW_ASSERT(data.getSize() + sizeof(LoRaConfig::HEADER) <= 252, data.getSize());
+    FW_ASSERT(this->m_lora_device != nullptr);
+    FW_ASSERT(device_is_ready(this->m_lora_device));
+    Fw::Success returnStatus = Fw::Success::SUCCESS;
+    Status status = this->enableTx();
+    if (status == Status::SUCCESS) {
+        ::memcpy(this->m_send_buffer, LoRaConfig::HEADER, sizeof(LoRaConfig::HEADER));
+        ::memcpy(this->m_send_buffer + sizeof(LoRaConfig::HEADER), data.getData(), data.getSize());
+        int send_status =
+            lora_send(this->m_lora_device, this->m_send_buffer, sizeof(LoRaConfig::HEADER) + data.getSize());
+        if (send_status != 0) {
+            this->log_WARNING_HI_SendFailed(static_cast<I32>(send_status));
+            returnStatus = Fw::Success::FAILURE;
+        } else {
+            returnStatus = Fw::Success::SUCCESS;
+            this->log_WARNING_HI_ConfigurationFailed_ThrottleClear();
+            this->log_WARNING_HI_SendFailed_ThrottleClear();
+        }
+    } else {
+        this->log_WARNING_HI_ConfigurationFailed(LoRaMode::Transmit);
+        returnStatus = Fw::Success::FAILURE;
+    }
+    // Enable RX mode after all TXes
+    status = this->enableRx();
+    if (status != Status::SUCCESS) {
+        this->log_WARNING_HI_ConfigurationFailed(LoRaMode::Receive);
+    }
+    this->dataReturnOut_out(0, data, context);
+    this->comStatusOut_out(0, returnStatus);
+}
+
+void LoRa ::dataReturnIn_handler(FwIndexType portNum, Fw::Buffer& data, const ComCfg::FrameContext& context) {
+    this->deallocate_out(0, data);
+}
+
+void LoRa ::receive(U8* data, U16 size, I16 rssi, I8 snr) {
+    const FwSizeType payload_size = static_cast<FwSizeType>(size - sizeof(LoRaConfig::HEADER));
+    Fw::Buffer buffer = this->allocate_out(0, payload_size);
+    if (buffer.isValid()) {
+        ::memcpy(buffer.getData() + sizeof(LoRaConfig::HEADER), data, payload_size);
+        ComCfg::FrameContext frameContext;
+        this->dataOut_out(0, buffer, frameContext);
+    } else {
+        this->log_WARNING_HI_AllocationFailed(size);
+    }
+    this->tlmWrite_LastRssi(rssi);
+    this->tlmWrite_LastSnr(snr);
+}
+
+// ----------------------------------------------------------------------
+// Handler implementations for commands
+// ----------------------------------------------------------------------
+
+void LoRa ::CONTINUOUS_WAVE_cmdHandler(FwOpcodeType opCode, U32 cmdSeq, U16 seconds) {
+    Status status = this->enableTx();
+    if (status == Status::SUCCESS) {
+        lora_test_cw(this->m_lora_device, LoRaConfig::FREQUENCY, LoRaConfig::TX_POWER, seconds);
+        status = this->enableRx();
+    }
+    this->cmdResponse_out(opCode, cmdSeq,
+                          (status == Status::SUCCESS) ? Fw::CmdResponse::OK : Fw::CmdResponse::EXECUTION_ERROR);
+}
+
+}  // namespace Zephyr

--- a/fprime-zephyr/Drv/LoRa/LoRa.cpp
+++ b/fprime-zephyr/Drv/LoRa/LoRa.cpp
@@ -5,7 +5,6 @@
 // ======================================================================
 
 #include "fprime-zephyr/Drv/LoRa/LoRa.hpp"
-#include "Fw/Logger/Logger.hpp"
 #include "zephyr-config/LoRaCfg.hpp"
 
 namespace Zephyr {
@@ -45,7 +44,7 @@ LoRa::Status LoRa ::start(const struct device* lora_device) {
 
     LoRa::Status config_status = this->enableRx();
     if (config_status != Status::SUCCESS) {
-        Fw::Logger::log("Failed to enable Rx");
+        this->log_WARNING_HI_ConfigurationFailed(LoRaMode::Receive);
         return LoRa::Status::ERROR;
     }
     Fw::Success status = Fw::Success::SUCCESS;
@@ -135,7 +134,7 @@ void LoRa ::receive(U8* data, U16 size, I16 rssi, I8 snr) {
     const FwSizeType payload_size = static_cast<FwSizeType>(size - sizeof(LoRaConfig::HEADER));
     Fw::Buffer buffer = this->allocate_out(0, payload_size);
     if (buffer.isValid()) {
-        ::memcpy(buffer.getData() + sizeof(LoRaConfig::HEADER), data, payload_size);
+        ::memcpy(buffer.getData(), data + sizeof(LoRaConfig::HEADER), payload_size);
         ComCfg::FrameContext frameContext;
         this->dataOut_out(0, buffer, frameContext);
     } else {

--- a/fprime-zephyr/Drv/LoRa/LoRa.fpp
+++ b/fprime-zephyr/Drv/LoRa/LoRa.fpp
@@ -1,0 +1,92 @@
+module Zephyr {
+    enum LoRaDataRate {
+        SF_6 = 6
+        SF_7 = 7
+        SF_8 = 8
+        SF_9 = 9
+        SF_10 = 10
+        SF_11 = 11
+        SF_12 = 12
+    }
+    enum LoRaCodingRate {
+        CR_4_5 = 1
+        CR_4_6 = 2
+        CR_4_7 = 3
+        CR_4_8 = 4
+    }
+    enum LoRaMode {
+        Transmit,
+        Receive
+    }
+
+    # TODO: Implement the LoRa driver functionality
+    # 1. Telemetry
+    # 2. Commands
+
+    @ Wrapper for the Zephyr LoRa driver
+    passive component LoRa {
+        @ Import the communication interface
+        import Svc.Com
+
+        @ Import the allocation interface
+        import Svc.Allocation
+
+        @ Coding rate: number of parity bits per 4 bit
+        param CODING_RATE: LoRaCodingRate default LoRaCodingRate.CR_4_5
+
+        @ Data rate / spreading factor
+        param DATA_RATE: LoRaDataRate default LoRaDataRate.SF_8
+
+        @ No-op command
+        sync command CONTINUOUS_WAVE(seconds: U16)
+
+        @ Event to indicate configuration failure
+        event ConfigurationFailed(mode: LoRaMode) severity warning high \
+            format "Failed to configure LoRa into mode: {}" throttle 2
+
+        @ Event to indicate configuration failure
+        event SendFailed(status: I32) severity warning high \
+            format "Failed to send LoRa message: {}" throttle 2
+        
+        @ Event to indicate allocation failure
+        event AllocationFailed(allocation_size: FwSizeType) severity warning high \
+            format "Failed to allocate buffer of: {} bytes" throttle 2
+
+        @ Last received RSSI
+        telemetry LastRssi: I16 update on change
+
+        @ Last received SNR
+        telemetry LastSnr: I8 update on change
+
+        ###############################################################################
+        # Standard AC Ports: Required for Channels, Events, Commands, and Parameters  #
+        ###############################################################################
+        @ Port for requesting the current time
+        time get port timeCaller
+
+        @ Port for sending command registrations
+        command reg port cmdRegOut
+
+        @ Port for receiving commands
+        command recv port cmdIn
+
+        @ Port for sending command responses
+        command resp port cmdResponseOut
+
+        @ Port for sending textual representation of events
+        text event port logTextOut
+
+        @ Port for sending events to downlink
+        event port logOut
+
+        @ Port for sending telemetry channels to downlink
+        telemetry port tlmOut
+
+        @ Port to return the value of a parameter
+        param get port prmGetOut
+
+        @Port to set the value of a parameter
+        param set port prmSetOut
+
+    }
+}

--- a/fprime-zephyr/Drv/LoRa/LoRa.hpp
+++ b/fprime-zephyr/Drv/LoRa/LoRa.hpp
@@ -1,0 +1,91 @@
+// ======================================================================
+// \title  LoRa.hpp
+// \author lestarch
+// \brief  hpp file for LoRa component implementation class
+// ======================================================================
+
+#ifndef Zephyr_LoRa_HPP
+#define Zephyr_LoRa_HPP
+
+#include <zephyr/drivers/lora.h>
+#include <Os/Mutex.hpp>
+#include "fprime-zephyr/Drv/LoRa/LoRaComponentAc.hpp"
+
+namespace Zephyr {
+
+class LoRa final : public LoRaComponentBase {
+  public:
+    // Status returned from various LoRa operations
+    enum Status { NOT_READY, NOT_INITIALIZED, ERROR, SUCCESS };
+    // ----------------------------------------------------------------------
+    // Component construction and destruction
+    // ----------------------------------------------------------------------
+
+    //! Construct LoRa object
+    LoRa(const char* const compName  //!< The component name
+    );
+
+    //! Destroy LoRa object
+    ~LoRa();
+
+    //! LoRa receive callback
+    static void receiveCallback(const struct device* dev, U8* data, U16 size, I16 rssi, I8 snr, void* user_data);
+
+    //! Configure LoRa radio the supplied device and start it
+    Status start(const struct device* lora_device);
+
+    //! Enable tx
+    Status enableTx();
+
+    //! Enable rx
+    Status enableRx();
+
+  private:
+    // ----------------------------------------------------------------------
+    // Handler implementations for typed input ports
+    // ----------------------------------------------------------------------
+
+    //! Handler implementation for dataIn
+    //!
+    //! Data to be sent on the wire (coming in to the component)
+    void dataIn_handler(FwIndexType portNum,  //!< The port number
+                        Fw::Buffer& data,
+                        const ComCfg::FrameContext& context) override;
+
+    //! Handler implementation for dataReturnIn
+    //!
+    //! Port receiving back ownership of buffer sent out on dataOut
+    void dataReturnIn_handler(FwIndexType portNum,  //!< The port number
+                              Fw::Buffer& data,
+                              const ComCfg::FrameContext& context) override;
+
+  private:
+    // ----------------------------------------------------------------------
+    // Handler implementations for commands
+    // ----------------------------------------------------------------------
+
+    //! Handler implementation for command CONTINUOUS_WAVE
+    //!
+    //! No-op command
+    void CONTINUOUS_WAVE_cmdHandler(FwOpcodeType opCode,  //!< The opcode
+                                    U32 cmdSeq,           //!< The command sequence number
+                                    U16 seconds) override;
+
+  private:
+    U8 m_send_buffer[252];  //!< Buffer for sending data (max LoRa packet size)
+    //! Process received data
+    //!
+    void receive(U8* data,  //!< Data to process
+                 U16 size,  //!< Size of the data
+                 I16 rssi,  //!< RSSI value for telemetry
+                 I8 snr     //!< SNR value for telemetry
+    );
+
+    //! Pointer to the LoRa device
+    const struct device* m_lora_device;
+    Os::Mutex m_mutex;  //!< Mutex for thread safety
+};
+
+}  // namespace Zephyr
+
+#endif

--- a/fprime-zephyr/Drv/LoRa/docs/sdd.md
+++ b/fprime-zephyr/Drv/LoRa/docs/sdd.md
@@ -1,0 +1,65 @@
+# Zephyr::LoRa
+
+Wrapper for the [Zephyr LoRa driver](https://docs.zephyrproject.org/latest/connectivity/lora_lorawan/index.html). This will integrate into the communication stack.
+
+### Typical Usage
+
+This is used as a radio in the F Prime communication stack transmitting via the LoRa radio.
+
+## Requirements
+
+| Name | Description | Validation |
+|---------|---|---|
+| LORA-01 | The LoRa component shall interface with the Zephyr Lora driver | INSPECTION |
+| LORA-02 | The LoRa component shall provide DATA_RATE and CODING_RATE as paramaters | Unit-Test |
+| LORA-03 | The LoRa component shall provide FREQUENCY, BANDWITH, TRANSMIT_POWER, and PREAMBLE as configurable parameters | Unit-Test |
+| LORA-04 | The LoRa component shall telemeter BytesSent and BytesRecv channels | Unit-Test |
+| LORA-05 | The LoRa component shall support the Svc.Com interface | Unit-Test |
+| LORA-06 | The LoRa component shall have a TEST_CW command for continuous-wave | Unit-Test |
+| LORA-07 | The LoRa component shall wrap the Zephyr LoRa driver | Unit-Test |
+| LORA-08 | The LoRa component shall configure the Zephyr LoRa driver for tranmit only when sending data | Unit-Test |
+
+
+## Port Interfaces
+
+| Name | Description |
+|---|---|
+| Svc.Com | Interface to plug the radio into the communication stack |
+
+
+## Configuration
+
+| Name | Description |
+|------|---|
+| FREQUENCY   | Frequency of the radio transmission / receive |
+| BANDWIDTH   | Number of parity bits sent             |
+| TX_POWER    | Transmission power of the raio |
+| PREAMBLE    | Preamble length in bytes |
+
+## Command
+
+| Name | Description |
+|------|---|
+| TEST_CW | Send continuous wave for a supplied duration |
+
+## Parameters
+
+| Name | Description |
+|------|---|
+| DATA_RATE   | Spreading factor / data rate for radio |
+| CODING_RATE | Number of parity bits sent             |
+
+## Telemetry
+
+| Name | Description |
+|---|---|
+| LastRssi | RSSI value of last receive |
+| LastSnr  | SNR value of last receive  |
+
+## Events
+
+| Name | Description |
+|---|---|
+| ConfigurationFailed | Failed to configure the LoRa radio |
+| SendFailed          | Failed to send data out LoRa radio |
+| AllocationFailed    | Failed to allocate buffer for received data|


### PR DESCRIPTION
This adds a manager component for using the LoRa radio in Zephyr (sx127x driver).  It has been tested with send/receive on a 0.1hz rate group using CCSDS framing.

> [!CAUTION]
> LoRa is fairly slow at transmitting.  It takes ~1S to send a full frame (252 Bytes).  Clocking downlink components at 1Hz effectively drown-out receive as it takes 1S to send the data produced every second.

