### PR TITLE
Add transmit commands

### DIFF
--- a/fprime-zephyr/Drv/LoRa/LoRa.fpp
+++ b/fprime-zephyr/Drv/LoRa/LoRa.fpp
@@ -18,6 +18,11 @@ module Zephyr {
         Transmit,
         Receive
     }
+    enum TransmitState : U8 {
+        ENABLED,
+        DISABLED,
+        DISABLING,
+    }
 
     @ Wrapper for the Zephyr LoRa driver
     passive component LoRa {
@@ -35,6 +40,9 @@ module Zephyr {
 
         @ Continuous wave transmission
         sync command CONTINUOUS_WAVE(seconds: U16)
+
+        @ Start/stop transmission on the LoRa module
+        sync command TRANSMIT(enabled: TransmitState)
 
         @ Event to indicate configuration failure
         event ConfigurationFailed(mode: LoRaMode) severity warning high \

--- a/fprime-zephyr/Drv/LoRa/LoRa.hpp
+++ b/fprime-zephyr/Drv/LoRa/LoRa.hpp
@@ -34,7 +34,7 @@ class LoRa final : public LoRaComponentBase {
     static void receiveCallback(const struct device* dev, U8* data, U16 size, I16 rssi, I8 snr, void* user_data);
 
     //! Configure LoRa radio the supplied device and start it
-    Status start(const struct device* lora_device);
+    Status start(const struct device* lora_device, const TransmitState& transmit_enabled);
 
     //! Enable tx
     Status enableTx();
@@ -72,6 +72,13 @@ class LoRa final : public LoRaComponentBase {
     void CONTINUOUS_WAVE_cmdHandler(FwOpcodeType opCode,  //!< The opcode
                                     U32 cmdSeq,           //!< The command sequence number
                                     U16 seconds) override;
+    
+    //! Handler implementation for command TRANSMIT
+    //!
+    //! Start/stop transmission on the LoRa module
+    void TRANSMIT_cmdHandler(FwOpcodeType opCode,  //!< The opcode
+                             U32 cmdSeq,           //!< The command sequence number
+                             TransmitState enabled) override;
 
   private:
     U8 m_send_buffer[LoRa::MAX_PACKET_SIZE];  //!< Buffer for sending data (max LoRa packet size)
@@ -85,6 +92,7 @@ class LoRa final : public LoRaComponentBase {
 
     //! Pointer to the LoRa device
     const struct device* m_lora_device;
+    Zephyr::TransmitState m_transmit_enabled;  //!< Transmit enabled state
     Os::Mutex m_mutex;  //!< Mutex for thread safety
 };
 


### PR DESCRIPTION
The LoRa radio can be used to broadcast on HAM frequencies, which require licenses for operating the radio.  Thus we need to provide an ability for users to start the radio in a non-transmit state and provide commands to turn on the radio.

Since the radio still listens, we can command through the radio or via a sequence to turn it on.  The start call takes the initial state so projects wanting the old behavior can configure it to do so.