### PR TITLE
Removed unused status varible

### DIFF
--- a/fprime-zephyr/Os/ConditionVariable.cpp
+++ b/fprime-zephyr/Os/ConditionVariable.cpp
@@ -25,6 +25,8 @@ ZephyrConditionVariable::~ZephyrConditionVariable() {
 ZephyrConditionVariable::Status ZephyrConditionVariable::pend(Os::Mutex& mutex) {
     ZephyrMutexHandle* mutex_handle = reinterpret_cast<ZephyrMutexHandle*>(mutex.getHandle());
     int status = k_condvar_wait(&this->m_handle.m_condition, &mutex_handle->m_mutex_descriptor, K_FOREVER);
+    // The only return code provided by the k_condvar_wait call is -EAGAIN when the timeout fails.  Since our
+    // timeout is set to K_FOREVER a non-zero exit status cannot happen.
     FW_ASSERT(status == 0, static_cast<FwAssertArgType>(status));
     return Status::OP_OK;
 }


### PR DESCRIPTION
Fix to removed the unused variable warning that occurs, when a fprime-zephyr project builds