### PR TITLE
remove `SPI read/write success` log

### DIFF
--- a/fprime-zephyr/Drv/ZephyrSpiDriver/ZephyrSpiDriver.cpp
+++ b/fprime-zephyr/Drv/ZephyrSpiDriver/ZephyrSpiDriver.cpp
@@ -74,8 +74,6 @@ void ZephyrSpiDriver ::SpiReadWrite_handler(FwIndexType portNum,
         printk("SPI read/write error: errno = %i\n", status);
       }
     }
-  } else {
-    printk("SPI read/write success\n");
   }
 }
 


### PR DESCRIPTION
Remove `SPI read/write success` log. When these transactions happen regularly, this log statement clutters the log.