### PR TITLE
Modify delay function signature to pass in interval by const reference (#4070)

### DIFF
--- a/fprime-zephyr/Os/Task.cpp
+++ b/fprime-zephyr/Os/Task.cpp
@@ -78,7 +78,7 @@ namespace Task {
     }
 
 
-    Os::Task::Status ZephyrTask::_delay(Fw::TimeInterval interval) {
+    Os::Task::Status ZephyrTask::_delay(const Fw::TimeInterval& interval) {
         uint32_t delay_ms = interval.getSeconds() * 1000 + interval.getUSeconds() / 1000;
         k_sleep(K_MSEC(delay_ms)); // Need better error checking
         return Os::Task::Status::OP_OK;

--- a/fprime-zephyr/Os/Task.hpp
+++ b/fprime-zephyr/Os/Task.hpp
@@ -83,7 +83,7 @@ namespace Task {
         //!
         //! \param interval: delay time
         //! \return status of the delay
-        Status _delay(Fw::TimeInterval interval) override;
+        Status _delay(const Fw::TimeInterval& interval) override;
 
         //! \brief return the underlying task handle (implementation specific)
         //! \return internal task handle representation


### PR DESCRIPTION
Update function signature to match changes made as part of https://github.com/nasa/fprime/pull/4751 .