### PR TITLE
Add Zephyr kmalloc-backed Fw::MemAllocator implementation

### DIFF
--- a/fprime-zephyr/Os/CMakeLists.txt
+++ b/fprime-zephyr/Os/CMakeLists.txt
@@ -72,6 +72,17 @@ register_fprime_implementation(
     "${CMAKE_CURRENT_LIST_DIR}/snprintk.cpp"
 )
 
+register_fprime_module(
+    Zephyr_KmallocAllocator
+  SOURCES
+    "${CMAKE_CURRENT_LIST_DIR}/KmallocAllocator.cpp"
+  HEADERS
+    "${CMAKE_CURRENT_LIST_DIR}/KmallocAllocator.hpp"
+  DEPENDS
+    Fw_Types
+    kernel
+)
+
 # Create a new File implementation that uses the File.cpp from the fprime posix implementation but provides alternate
 # Directory and FileSystem implementations to work with Zephyr's subset of POSIX.
 #

--- a/fprime-zephyr/Os/KmallocAllocator.cpp
+++ b/fprime-zephyr/Os/KmallocAllocator.cpp
@@ -1,0 +1,47 @@
+#include <fprime-zephyr/Os/KmallocAllocator.hpp>
+
+#include <zephyr/kernel.h>
+
+namespace Zephyr {
+
+bool KmallocAllocator::isPowerOfTwo(const FwSizeType value) {
+    return (value != 0U) && ((value & (value - 1U)) == 0U);
+}
+
+FwSizeType KmallocAllocator::normalizeAlignment(FwSizeType alignment) {
+    const auto pointerAlignment = static_cast<FwSizeType>(sizeof(void*));
+    if (alignment < pointerAlignment) {
+        return pointerAlignment;
+    }
+    return alignment;
+}
+
+void* KmallocAllocator::allocate(const FwEnumStoreType identifier,
+                                 FwSizeType& size,
+                                 bool& recoverable,
+                                 FwSizeType alignment) {
+    static_cast<void>(identifier);
+
+    recoverable = false;
+    if (size == 0U) {
+        return nullptr;
+    }
+
+    alignment = normalizeAlignment(alignment);
+    if (!isPowerOfTwo(alignment)) {
+        return nullptr;
+    }
+
+    if (alignment <= static_cast<FwSizeType>(sizeof(void*))) {
+        return k_malloc(size);
+    }
+
+    return k_aligned_alloc(alignment, size);
+}
+
+void KmallocAllocator::deallocate(const FwEnumStoreType identifier, void* ptr) {
+    static_cast<void>(identifier);
+    k_free(ptr);
+}
+
+}  // namespace Zephyr

--- a/fprime-zephyr/Os/KmallocAllocator.hpp
+++ b/fprime-zephyr/Os/KmallocAllocator.hpp
@@ -1,0 +1,35 @@
+#ifndef FPRIME_ZEPHYR_OS_KMALLOCALLOCATOR_HPP
+#define FPRIME_ZEPHYR_OS_KMALLOCALLOCATOR_HPP
+
+#include <Fw/Types/MemAllocator.hpp>
+
+#include <cstddef>
+
+namespace Zephyr {
+
+//! \class KmallocAllocator
+//! \brief Fw::MemAllocator implementation backed by Zephyr's system heap.
+//!
+//! Routes allocations through k_malloc / k_aligned_alloc and releases them
+//! via k_free. Requires CONFIG_HEAP_MEM_POOL_SIZE to be set in the
+//! deployment's prj.conf.
+class KmallocAllocator final : public Fw::MemAllocator {
+  public:
+    KmallocAllocator() = default;
+    ~KmallocAllocator() override = default;
+
+    void* allocate(FwEnumStoreType identifier,
+                   FwSizeType& size,
+                   bool& recoverable,
+                   FwSizeType alignment = alignof(std::max_align_t)) override;
+
+    void deallocate(FwEnumStoreType identifier, void* ptr) override;
+
+  private:
+    static bool isPowerOfTwo(FwSizeType value);
+    static FwSizeType normalizeAlignment(FwSizeType alignment);
+};
+
+}  // namespace Zephyr
+
+#endif


### PR DESCRIPTION
## Summary

Adds `Zephyr::KmallocAllocator` under `fprime-zephyr/Os/`, a concrete `Fw::MemAllocator` implementation backed by Zephyr's system heap. Allocations go through `k_malloc` / `k_aligned_alloc`; releases go through `k_free`. Registered as a plain fprime module (not an `Os_*` interface swap), since `Fw::MemAllocator` is instantiated directly by topology code rather than selected at link time.

Today, Zephyr-based F´ deployments have to route `Fw::MemAllocator` through libc malloc — the `sample-config/prj.conf` comment even calls this out (*"LIBC malloc calls are needed for Fw::MemAllocator"*). This module gives downstream deployments a drop-in Zephyr-native option so memory ownership can sit with the RTOS.

## Implementation Notes

- `fprime-zephyr/Os/KmallocAllocator.{hpp,cpp}` — `namespace Zephyr`, `final` class, no virtual state
- Uses `k_aligned_alloc` only when the requested alignment exceeds pointer-size alignment; falls back to `k_malloc` otherwise
- Rejects non-power-of-two alignments and zero-size allocations
- `recoverable` is always set to `false` (Zephyr's heap does not persist across resets)
- Registered in `Os/CMakeLists.txt` as `Zephyr_KmallocAllocator` via `register_fprime_module` (depends on `Fw_Types`, `kernel`)

## Consumer Requirements

Deployments using this allocator must enable Zephyr's system heap in their `prj.conf`, e.g.:

```
CONFIG_HEAP_MEM_POOL_SIZE=8192
```

## Testing

- Consumed from `fprime-zephyr-reference` via submodule bump; topology builds and links for `BOARD=teensy41` and produces final Zephyr artifacts (`zephyr.elf`, `zephyr.hex`).
- Companion deployment PR: fprime-community/fprime-zephyr-reference#30 (will be updated / closed against this PR).

## Reference

https://docs.zephyrproject.org/latest/kernel/memory_management/heap.html