### PR TITLE
Add LoRa SET_FREQ command

### DIFF
--- a/default/zephyr-config/LoRaCfg.hpp
+++ b/default/zephyr-config/LoRaCfg.hpp
@@ -3,7 +3,7 @@
 #include <zephyr/drivers/lora.h>
 #include <Fw/FPrimeBasicTypes.hpp>
 namespace LoRaConfig {
-const U32 FREQUENCY = 915000000;               // 437400000; //!< LoRa frequency in Hz
+const U32 DEFAULT_FREQ = 915000000;            // 437400000; //!< LoRa frequency in Hz
 lora_signal_bandwidth BANDWIDTH = BW_125_KHZ;  //!< LoRa bandwidth
 const I8 TX_POWER = 14;                        //!< LoRa transmission power in dBm
 const U16 PREAMBLE_LENGTH = 8;                 //!< LoRa preamble length

--- a/fprime-zephyr/Drv/LoRa/LoRa.cpp
+++ b/fprime-zephyr/Drv/LoRa/LoRa.cpp
@@ -11,7 +11,7 @@ namespace Zephyr {
 
 // Base configuration for the LoRa modem
 struct lora_modem_config BASE_CONFIG = {
-    .frequency = LoRaConfig::FREQUENCY,
+    .frequency = LoRaConfig::DEFAULT_FREQ,
     .bandwidth = BW_125_KHZ,
     .datarate = SF_8,
     .coding_rate = CR_4_5,
@@ -183,9 +183,18 @@ void LoRa ::receive(U8* data, U16 size, I16 rssi, I8 snr) {
 void LoRa ::CONTINUOUS_WAVE_cmdHandler(FwOpcodeType opCode, U32 cmdSeq, U16 seconds) {
     Status status = this->enableTx();
     if (status == Status::SUCCESS) {
-        lora_test_cw(this->m_lora_device, LoRaConfig::FREQUENCY, LoRaConfig::TX_POWER, seconds);
+        lora_test_cw(this->m_lora_device, BASE_CONFIG.frequency, LoRaConfig::TX_POWER, seconds);
         status = this->enableRx();
     }
+    this->cmdResponse_out(opCode, cmdSeq,
+                          (status == Status::SUCCESS) ? Fw::CmdResponse::OK : Fw::CmdResponse::EXECUTION_ERROR);
+}
+
+void LoRa ::SET_FREQ_cmdHandler(FwOpcodeType opCode, U32 cmdSeq, U32 freq_hz) {
+    Os::ScopeLock lock(this->m_mutex);
+    lora_recv_async(this->m_lora_device, nullptr, nullptr);
+    BASE_CONFIG.frequency = freq_hz;
+    Status status = this->enableRx();
     this->cmdResponse_out(opCode, cmdSeq,
                           (status == Status::SUCCESS) ? Fw::CmdResponse::OK : Fw::CmdResponse::EXECUTION_ERROR);
 }

--- a/fprime-zephyr/Drv/LoRa/LoRa.fpp
+++ b/fprime-zephyr/Drv/LoRa/LoRa.fpp
@@ -52,6 +52,9 @@ module Zephyr {
         @ Continuous wave transmission
         sync command CONTINUOUS_WAVE(seconds: U16)
 
+        @ Set the LoRa frequency in Hz
+        sync command SET_FREQ(freq_hz: U32)
+
         @ Start/stop transmission on the LoRa module
         sync command TRANSMIT(enabled: TransmitState)
 

--- a/fprime-zephyr/Drv/LoRa/LoRa.hpp
+++ b/fprime-zephyr/Drv/LoRa/LoRa.hpp
@@ -72,6 +72,13 @@ class LoRa final : public LoRaComponentBase {
     void CONTINUOUS_WAVE_cmdHandler(FwOpcodeType opCode,  //!< The opcode
                                     U32 cmdSeq,           //!< The command sequence number
                                     U16 seconds) override;
+
+    //! Handler implementation for command SET_FREQ
+    //!
+    //! Set the LoRa frequency in Hz
+    void SET_FREQ_cmdHandler(FwOpcodeType opCode,  //!< The opcode
+                             U32 cmdSeq,           //!< The command sequence number
+                             U32 freq_hz) override;
     
     //! Handler implementation for command TRANSMIT
     //!


### PR DESCRIPTION
For [a ground station component](https://github.com/Open-Source-Space-Foundation/ground-radio-controller/) for the PROVES project, I needed the ability to dynamically set the carrier frequency of the LoRa radio. So I made this patch for the LoRa component.

This command is arguably unsafe for a satellite. Setting the carrier frequency to an invalid value *could* knock out the radio. And Zephyr doesn't seem to do any checks on the frequency set with `lora_config` to see if it's valid so we can't rely on it to protect us.

In light of that I'm not sure if you would like it upstream. Maybe it would be better with a user-configured guard on the acceptable input range of SET_FREQ. Or, if it's possible, to feature-gate the command and have it default to disabled. Or both.

I leave it here for your consideration.