### PR TITLE
Fix LoRa CONTINUOUS_WAVE failing after the first call

### DIFF
--- a/fprime-zephyr/Drv/LoRa/LoRa.cpp
+++ b/fprime-zephyr/Drv/LoRa/LoRa.cpp
@@ -7,7 +7,12 @@
 #include "fprime-zephyr/Drv/LoRa/LoRa.hpp"
 #include "zephyr-config/LoRaCfg.hpp"
 #include <Fw/Logger/Logger.hpp>
+#include <zephyr/kernel.h>
 namespace Zephyr {
+
+// Extra time to wait, beyond the requested continuous-wave duration, for the
+// radio's TxTimeout handler to fire and release the modem before re-arming RX.
+static constexpr U32 CW_TEARDOWN_MARGIN_MS = 250;
 
 // Base configuration for the LoRa modem
 struct lora_modem_config BASE_CONFIG = {
@@ -181,10 +186,33 @@ void LoRa ::receive(U8* data, U16 size, I16 rssi, I8 snr) {
 // ----------------------------------------------------------------------
 
 void LoRa ::CONTINUOUS_WAVE_cmdHandler(FwOpcodeType opCode, U32 cmdSeq, U16 seconds) {
+    Os::ScopeLock lock(this->m_mutex);
     Status status = this->enableTx();
     if (status == Status::SUCCESS) {
-        lora_test_cw(this->m_lora_device, LoRaConfig::FREQUENCY, LoRaConfig::TX_POWER, seconds);
-        status = this->enableRx();
+        // lora_test_cw() is asynchronous: it acquires the modem and kicks off a
+        // continuous wave that transmits for `seconds`, returning immediately while
+        // the modem stays BUSY. The radio's TxTimeout handler releases the modem only
+        // when the CW finishes. Re-arming RX before that release races the still-BUSY
+        // modem and fails with -EBUSY, which (previously) left RX disarmed and wedged
+        // the modem for every later command until a board reset (issue #207). Block
+        // here until the CW completes so the modem is FREE before we re-enable RX.
+        int cw_status = lora_test_cw(this->m_lora_device, LoRaConfig::FREQUENCY, LoRaConfig::TX_POWER, seconds);
+        if (cw_status != 0) {
+            status = Status::ERROR;
+        } else {
+            k_sleep(K_MSEC(static_cast<U32>(seconds) * 1000U + CW_TEARDOWN_MARGIN_MS));
+        }
+    }
+    // Always re-arm RX, even on the TX/CW error path. A single failure must not be
+    // able to leave the modem without an active async receive, which is what forced a
+    // reset before (issue #207). enableRx() also recovers a modem left FREE by a prior
+    // failure, so one run of this handler heals a previously wedged radio.
+    Status rx_status = this->enableRx();
+    if (rx_status != Status::SUCCESS) {
+        this->log_WARNING_HI_ConfigurationFailed(LoRaMode::Receive);
+        if (status == Status::SUCCESS) {
+            status = rx_status;
+        }
     }
     this->cmdResponse_out(opCode, cmdSeq,
                           (status == Status::SUCCESS) ? Fw::CmdResponse::OK : Fw::CmdResponse::EXECUTION_ERROR);


### PR DESCRIPTION
> ⚠️ **Heads-up for maintainers:** this PR was prepared by an AI agent (Claude) working with a human operator. Please review accordingly.

### Summary
`LoRa::CONTINUOUS_WAVE_cmdHandler` called `enableRx()` immediately after `lora_test_cw()`, but `lora_test_cw()` is asynchronous: it holds the modem BUSY while the CW transmits and the radio's `TxTimeout` handler frees it only when the burst ends. The immediate `enableRx()` raced the BUSY modem (`-EBUSY`), returned `EXECUTION_ERROR`, and left async RX disarmed — so the next `CONTINUOUS_WAVE` failed in `enableTx()` and no further transmission happened until a board reset.

### Fix
Block until the CW completes before re-arming RX, always re-arm RX (even on the error path) so one failure can't wedge the modem, and guard the sequence with the component mutex.

### Verification
Tested on RP2350 / SX127x hardware with a GDB watchpoint on `dev_data.modem_usage`: across two back-to-back `CONTINUOUS_WAVE` commands the modem now returns to FREE via the `TxTimeout` handler and is re-armed for async RX after each call.