### PR TITLE
Drv/ZephyrUartDriver: Add hardware flow control configuration

### DIFF
--- a/fprime-zephyr/Drv/LoRa/LoRa.cpp
+++ b/fprime-zephyr/Drv/LoRa/LoRa.cpp
@@ -190,7 +190,7 @@ void LoRa ::CONTINUOUS_WAVE_cmdHandler(FwOpcodeType opCode, U32 cmdSeq, U16 seco
                           (status == Status::SUCCESS) ? Fw::CmdResponse::OK : Fw::CmdResponse::EXECUTION_ERROR);
 }
 
-void LoRa ::TRANSMIT_cmdHandler(FwOpcodeType opCode, U32 cmdSeq, TransmitState enabled) {
+void LoRa ::TRANSMIT_cmdHandler(FwOpcodeType opCode, U32 cmdSeq, const TransmitState& enabled) {
     Os::ScopeLock lock(this->m_mutex);
     // Want to enable
     if (enabled == TransmitState::ENABLED) {

--- a/fprime-zephyr/Drv/LoRa/LoRa.hpp
+++ b/fprime-zephyr/Drv/LoRa/LoRa.hpp
@@ -78,7 +78,7 @@ class LoRa final : public LoRaComponentBase {
     //! Start/stop transmission on the LoRa module
     void TRANSMIT_cmdHandler(FwOpcodeType opCode,  //!< The opcode
                              U32 cmdSeq,           //!< The command sequence number
-                             TransmitState enabled) override;
+                             const TransmitState& enabled) override;
 
   private:
     U8 m_send_buffer[LoRa::MAX_PACKET_SIZE];  //!< Buffer for sending data (max LoRa packet size)

--- a/fprime-zephyr/Drv/ZephyrUartDriver/ZephyrUartDriver.cpp
+++ b/fprime-zephyr/Drv/ZephyrUartDriver/ZephyrUartDriver.cpp
@@ -4,117 +4,96 @@
 // \brief  cpp file for ZephyrUartDriver component implementation class
 // ======================================================================
 
-
 #include "fprime-zephyr/Drv/ZephyrUartDriver/ZephyrUartDriver.hpp"
-#include "Fw/Types/BasicTypes.hpp"
-#include "Fw/Types/Assert.hpp"
 #include <Fw/FPrimeBasicTypes.hpp>
+#include "Fw/Types/Assert.hpp"
+#include "Fw/Types/BasicTypes.hpp"
 
 namespace Zephyr {
 
-    // ----------------------------------------------------------------------
-    // Construction, initialization, and destruction
-    // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Construction, initialization, and destruction
+// ----------------------------------------------------------------------
 
-    ZephyrUartDriver ::
-        ZephyrUartDriver(
-            const char *const compName
-        ) : ZephyrUartDriverComponentBase(compName)
-    {
+ZephyrUartDriver ::ZephyrUartDriver(const char* const compName) : ZephyrUartDriverComponentBase(compName) {}
+
+ZephyrUartDriver ::~ZephyrUartDriver() {}
+
+void ZephyrUartDriver::configure(const struct device* dev, U32 baud_rate, uart_config_flow_control flow_ctrl) {
+    FW_ASSERT(dev != nullptr);
+    m_dev = dev;
+
+    if (!device_is_ready(this->m_dev)) {
+        return;
     }
 
-    ZephyrUartDriver ::
-        ~ZephyrUartDriver()
-    {
+    struct uart_config uart_cfg = {
+        .baudrate = baud_rate,
+        .parity = UART_CFG_PARITY_NONE,
+        .stop_bits = UART_CFG_STOP_BITS_1,
+        .data_bits = UART_CFG_DATA_BITS_8,
+        .flow_ctrl = flow_ctrl,
+    };
+    uart_configure(this->m_dev, &uart_cfg);
 
+    ring_buf_init(&this->m_ring_buf, RING_BUF_SIZE, this->m_ring_buf_data);
+    uart_irq_callback_user_data_set(this->m_dev, serial_cb, &this->m_ring_buf);
+
+    uart_irq_rx_enable(this->m_dev);
+    uart_irq_tx_disable(this->m_dev);
+
+    if (this->isConnected_ready_OutputPort(0)) {
+        this->ready_out(0);
+    }
+}
+
+void ZephyrUartDriver::serial_cb(const struct device* dev, void* user_data) {
+    struct ring_buf* ring_buf = reinterpret_cast<struct ring_buf*>(user_data);
+
+    if (!uart_irq_update(dev)) {
+        return;
     }
 
-    void ZephyrUartDriver::configure(const struct device *dev, U32 baud_rate) {
-        FW_ASSERT(dev != nullptr);
-        m_dev = dev;
-
-        if (!device_is_ready(this->m_dev)) {
-            return;
-        }
-
-        struct uart_config uart_cfg = {
-            .baudrate = baud_rate,
-            .parity = UART_CFG_PARITY_NONE,
-            .stop_bits = UART_CFG_STOP_BITS_1,
-            .data_bits = UART_CFG_DATA_BITS_8,
-            .flow_ctrl = UART_CFG_FLOW_CTRL_NONE,
-        };
-        uart_configure(this->m_dev, &uart_cfg);
-
-        ring_buf_init(&this->m_ring_buf, RING_BUF_SIZE, this->m_ring_buf_data);
-        uart_irq_callback_user_data_set(this->m_dev, serial_cb, &this->m_ring_buf);
-
-        uart_irq_rx_enable(this->m_dev);
-	    uart_irq_tx_disable(this->m_dev);
-
-        if (this->isConnected_ready_OutputPort(0)) {
-            this->ready_out(0);
-        }
+    if (!uart_irq_rx_ready(dev)) {
+        return;
     }
 
-    void ZephyrUartDriver::serial_cb(const struct device *dev, void *user_data)
-    {
-        struct ring_buf *ring_buf = reinterpret_cast<struct ring_buf *>(user_data);
-
-        if (!uart_irq_update(dev)) {
-            return;
-        }
-
-        if (!uart_irq_rx_ready(dev)) {
-            return;
-        }
-
-        U8 c;
-        // TODO: Get rid of the endless loop (in an IRQ handler!).
-        while (uart_fifo_read(dev, &c, 1) == 1) {
-            if (ring_buf_put(ring_buf, &c, 1) != 1) {
-                // TODO: Handle properly.
-                printk("UART buffer overrun\n");
-            }
+    U8 c;
+    // TODO: Get rid of the endless loop (in an IRQ handler!).
+    while (uart_fifo_read(dev, &c, 1) == 1) {
+        if (ring_buf_put(ring_buf, &c, 1) != 1) {
+            // TODO: Handle properly.
+            printk("UART buffer overrun\n");
         }
     }
+}
 
-    // ----------------------------------------------------------------------
-    // Handler implementations for user-defined typed input ports
-    // ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// Handler implementations for user-defined typed input ports
+// ----------------------------------------------------------------------
 
-    void ZephyrUartDriver ::
-        schedIn_handler(
-            const FwIndexType portNum,
-            U32 context
-        )
-    {
-        Fw::Buffer recv_buffer = this->allocate_out(0, SERIAL_BUFFER_SIZE);
+void ZephyrUartDriver ::schedIn_handler(const FwIndexType portNum, U32 context) {
+    Fw::Buffer recv_buffer = this->allocate_out(0, SERIAL_BUFFER_SIZE);
 
-        U32 recv_size = ring_buf_get(&this->m_ring_buf, recv_buffer.getData(), recv_buffer.getSize());
-        if (recv_size == 0) {
-            // No data received, deallocate buffer
-            this->deallocate_out(0, recv_buffer);
-        } else {
-            recv_buffer.setSize(recv_size);
-            recv_out(0, recv_buffer, Drv::ByteStreamStatus::OP_OK);
-        }
+    U32 recv_size = ring_buf_get(&this->m_ring_buf, recv_buffer.getData(), recv_buffer.getSize());
+    if (recv_size == 0) {
+        // No data received, deallocate buffer
+        this->deallocate_out(0, recv_buffer);
+    } else {
+        recv_buffer.setSize(recv_size);
+        recv_out(0, recv_buffer, Drv::ByteStreamStatus::OP_OK);
     }
+}
 
-    Drv::ByteStreamStatus ZephyrUartDriver ::
-        send_handler(
-            const FwIndexType portNum,
-            Fw::Buffer &sendBuffer
-        )
-    {
-        for (U32 i = 0; i < sendBuffer.getSize(); i++) {
-            uart_poll_out(this->m_dev, sendBuffer.getData()[i]);
-        }
-        return Drv::ByteStreamStatus::OP_OK;
+Drv::ByteStreamStatus ZephyrUartDriver ::send_handler(const FwIndexType portNum, Fw::Buffer& sendBuffer) {
+    for (U32 i = 0; i < sendBuffer.getSize(); i++) {
+        uart_poll_out(this->m_dev, sendBuffer.getData()[i]);
     }
+    return Drv::ByteStreamStatus::OP_OK;
+}
 
-    void ZephyrUartDriver ::recvReturnIn_handler(const FwIndexType portNum, Fw::Buffer &returnBuffer) {
-        this->deallocate_out(0, returnBuffer);
-    }
+void ZephyrUartDriver ::recvReturnIn_handler(const FwIndexType portNum, Fw::Buffer& returnBuffer) {
+    this->deallocate_out(0, returnBuffer);
+}
 
-} // end namespace Zephyr
+}  // end namespace Zephyr

--- a/fprime-zephyr/Drv/ZephyrUartDriver/ZephyrUartDriver.hpp
+++ b/fprime-zephyr/Drv/ZephyrUartDriver/ZephyrUartDriver.hpp
@@ -9,75 +9,68 @@
 
 #include "fprime-zephyr/Drv/ZephyrUartDriver/ZephyrUartDriverComponentAc.hpp"
 
-#include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/uart.h>
+#include <zephyr/kernel.h>
 #include <zephyr/sys/ring_buffer.h>
 
 #define RING_BUF_SIZE 1024
 
 namespace Zephyr {
 
-  class ZephyrUartDriver :
-    public ZephyrUartDriverComponentBase
-  {
-
+class ZephyrUartDriver : public ZephyrUartDriverComponentBase {
     const FwSizeType SERIAL_BUFFER_SIZE = 64;
 
-    public:
+  public:
+    // ----------------------------------------------------------------------
+    // Construction, initialization, and destruction
+    // ----------------------------------------------------------------------
 
-        // ----------------------------------------------------------------------
-        // Construction, initialization, and destruction
-        // ----------------------------------------------------------------------
+    //! Construct object ZephyrUartDriver
+    //!
+    ZephyrUartDriver(const char* const compName /*!< The component name*/
+    );
 
-        //! Construct object ZephyrUartDriver
-        //!
-        ZephyrUartDriver(
-            const char *const compName /*!< The component name*/
-        );
+    //! Destroy object ZephyrUartDriver
+    //!
+    ~ZephyrUartDriver();
 
-        //! Destroy object ZephyrUartDriver
-        //!
-        ~ZephyrUartDriver();
+    void configure(const struct device* dev, /*!< The Zephyr device structure for the UART */
+                   U32 baud_rate,            /*!< The desired baud rate (e.g., 115200) */
+                   uart_config_flow_control flow_ctrl =
+                       UART_CFG_FLOW_CTRL_NONE /*!< Hardware flow control setting (default: None). Use
+                                                  UART_CFG_FLOW_CTRL_RTS_CTS to enable RTS/CTS. */
+    );
 
-        void configure(const struct device *dev, U32 baud_rate);
+  public:
+    static void serial_cb(const struct device* dev, void* user_data);
 
-    public:
+    // ----------------------------------------------------------------------
+    // Handler implementations for user-defined typed input ports
+    // ----------------------------------------------------------------------
 
-        static void serial_cb(const struct device *dev, void *user_data);
+    //! Handler implementation for schedIn
+    //!
+    void schedIn_handler(const FwIndexType portNum, /*!< The port number*/
+                         U32 context                /*!<
+                                    The call order
+                                    */
+    );
 
-        // ----------------------------------------------------------------------
-        // Handler implementations for user-defined typed input ports
-        // ----------------------------------------------------------------------
+    //! Handler implementation for send
+    //!
+    Drv::ByteStreamStatus send_handler(const FwIndexType portNum, /*!< The port number*/
+                                       Fw::Buffer& sendBuffer);
 
-        //! Handler implementation for schedIn
-        //!
-        void schedIn_handler(
-            const FwIndexType portNum, /*!< The port number*/
-            U32 context /*!< 
-        The call order
-        */
-        );
+    void recvReturnIn_handler(const FwIndexType portNum, /*!< The port number*/
+                              Fw::Buffer& returnBuffer);
 
+    const struct device* m_dev;
 
-        //! Handler implementation for send
-        //!
-        Drv::ByteStreamStatus send_handler(
-            const FwIndexType portNum, /*!< The port number*/
-            Fw::Buffer &sendBuffer 
-        );
+    U8 m_ring_buf_data[RING_BUF_SIZE];
+    struct ring_buf m_ring_buf;
+};
 
-        void recvReturnIn_handler(
-            const FwIndexType portNum, /*!< The port number*/
-            Fw::Buffer &returnBuffer
-        );
-
-        const struct device *m_dev;
-
-        U8 m_ring_buf_data[RING_BUF_SIZE];
-        struct ring_buf m_ring_buf;
-    };
-
-} // end namespace Zephyr
+}  // end namespace Zephyr
 
 #endif


### PR DESCRIPTION
Previously, the ZephyrUartDriver hardcoded the flow control setting to UART_CFG_FLOW_CTRL_NONE, preventing deployments from utilizing RTS/CTS.

This update:
- Adds an optional flow_ctrl parameter to the configure() method.
- Defaults the parameter to UART_CFG_FLOW_CTRL_NONE to maintain strict backwards compatibility with all existing topologies.
- Allows developers to dynamically enable hardware flow control during topology initialization by passing UART_CFG_FLOW_CTRL_RTS_CTS.