### PR TITLE
Ble usb dual support

### DIFF
--- a/fprime-zephyr/Drv/ZephyrUartDriver/ZephyrUartDriver.cpp
+++ b/fprime-zephyr/Drv/ZephyrUartDriver/ZephyrUartDriver.cpp
@@ -9,6 +9,9 @@
 #include "Fw/Types/BasicTypes.hpp"
 #include "Fw/Types/Assert.hpp"
 #include <Fw/FPrimeBasicTypes.hpp>
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(ZephyrUartDriver, LOG_LEVEL_NONE);
 
 namespace Zephyr {
 
@@ -19,7 +22,8 @@ namespace Zephyr {
     ZephyrUartDriver ::
         ZephyrUartDriver(
             const char *const compName
-        ) : ZephyrUartDriverComponentBase(compName)
+        ) : ZephyrUartDriverComponentBase(compName), 
+        m_rx_throttled(false)
     {
     }
 
@@ -47,7 +51,7 @@ namespace Zephyr {
         uart_configure(this->m_dev, &uart_cfg);
 
         ring_buf_init(&this->m_ring_buf, RING_BUF_SIZE, this->m_ring_buf_data);
-        uart_irq_callback_user_data_set(this->m_dev, serial_cb, &this->m_ring_buf);
+        uart_irq_callback_user_data_set(this->m_dev, serial_cb, this);
 
         uart_irq_rx_enable(this->m_dev);
 	    uart_irq_tx_disable(this->m_dev);
@@ -59,24 +63,37 @@ namespace Zephyr {
 
     void ZephyrUartDriver::serial_cb(const struct device *dev, void *user_data)
     {
-        struct ring_buf *ring_buf = reinterpret_cast<struct ring_buf *>(user_data);
+        struct ZephyrUartDriver *self = reinterpret_cast<ZephyrUartDriver *>(user_data);
 
-        if (!uart_irq_update(dev)) {
-            return;
-        }
-
-        if (!uart_irq_rx_ready(dev)) {
-            return;
-        }
-
-        U8 c;
-        // TODO: Get rid of the endless loop (in an IRQ handler!).
-        while (uart_fifo_read(dev, &c, 1) == 1) {
-            if (ring_buf_put(ring_buf, &c, 1) != 1) {
-                // TODO: Handle properly.
-                printk("UART buffer overrun\n");
+        while (uart_irq_update(dev) && uart_irq_is_pending(dev)) {
+            if (!self->m_rx_throttled && uart_irq_rx_ready(dev)) {
+                int recv_len, rb_len;
+                uint8_t buffer[SERIAL_BUFFER_SIZE];
+                size_t len = MIN(ring_buf_space_get(&self->m_ring_buf),
+                         sizeof(buffer));
+    
+                if (len == 0) {
+                    /* Throttle because ring buffer is full */
+                    uart_irq_rx_disable(dev);
+                    self->m_rx_throttled = true;
+                    continue;
+                }
+    
+                recv_len = uart_fifo_read(dev, buffer, len);
+                if (recv_len < 0) {
+                    LOG_ERR("Failed to read UART FIFO");
+                    recv_len = 0;
+                };
+    
+                rb_len = ring_buf_put(&self->m_ring_buf, buffer, recv_len);
+                if (rb_len < recv_len) {
+                    LOG_ERR("Drop %u bytes", recv_len - rb_len);
+                }
+    
+                LOG_INF("IRQ rx: %d bytes -> ringbuf", rb_len);
             }
         }
+    
     }
 
     // ----------------------------------------------------------------------
@@ -89,6 +106,9 @@ namespace Zephyr {
             U32 context
         )
     {
+        if (ring_buf_is_empty(&this->m_ring_buf)) {
+            return; 
+        }
         Fw::Buffer recv_buffer = this->allocate_out(0, SERIAL_BUFFER_SIZE);
 
         U32 recv_size = ring_buf_get(&this->m_ring_buf, recv_buffer.getData(), recv_buffer.getSize());
@@ -97,7 +117,12 @@ namespace Zephyr {
             this->deallocate_out(0, recv_buffer);
         } else {
             recv_buffer.setSize(recv_size);
+            LOG_INF("schedIn: %u bytes -> recv_out", recv_size);
             recv_out(0, recv_buffer, Drv::ByteStreamStatus::OP_OK);
+        }
+        if (this->m_rx_throttled) {
+            uart_irq_rx_enable(this->m_dev);
+            this->m_rx_throttled = false;
         }
     }
 
@@ -107,6 +132,7 @@ namespace Zephyr {
             Fw::Buffer &sendBuffer
         )
     {
+        LOG_INF("TX: %u bytes", (unsigned int)sendBuffer.getSize());
         for (U32 i = 0; i < sendBuffer.getSize(); i++) {
             uart_poll_out(this->m_dev, sendBuffer.getData()[i]);
         }
@@ -114,6 +140,7 @@ namespace Zephyr {
     }
 
     void ZephyrUartDriver ::recvReturnIn_handler(const FwIndexType portNum, Fw::Buffer &returnBuffer) {
+        LOG_INF("Buffer deallocated, size=%u", (unsigned int)returnBuffer.getSize());
         this->deallocate_out(0, returnBuffer);
     }
 

--- a/fprime-zephyr/Drv/ZephyrUartDriver/ZephyrUartDriver.cpp
+++ b/fprime-zephyr/Drv/ZephyrUartDriver/ZephyrUartDriver.cpp
@@ -11,8 +11,6 @@
 #include <Fw/FPrimeBasicTypes.hpp>
 #include <zephyr/logging/log.h>
 
-LOG_MODULE_REGISTER(ZephyrUartDriver, LOG_LEVEL_NONE);
-
 namespace Zephyr {
 
     // ----------------------------------------------------------------------
@@ -35,6 +33,7 @@ namespace Zephyr {
     }
 
     void ZephyrUartDriver::configure(const struct device *bleDev, const struct device *usbDev, U32 baud_rate) {
+        LOG_ERR("Yay this log shows up");
         FW_ASSERT(bleDev != nullptr);
         FW_ASSERT(usbDev != nullptr);
         m_ble_dev = bleDev;
@@ -154,13 +153,11 @@ namespace Zephyr {
     // ----------------------------------------------------------------------
 
     void ZephyrUartDriver :: schedIn_handler(const FwIndexType portNum, U32 context) {
+
+        Fw::Buffer recv_buffer = this->allocate_out(0, SERIAL_BUFFER_SIZE);
+
         ActiveUart active_uart = this->m_last_rx_ble_ms >= this->m_last_rx_usb_ms ? ActiveUart::BLE : ActiveUart::USB;
         if (active_uart == ActiveUart::BLE) {
-            if (ring_buf_is_empty(&this->m_ring_buf_ble)) {
-                return; 
-            }
-
-            Fw::Buffer recv_buffer = this->allocate_out(0, SERIAL_BUFFER_SIZE);
 
             U32 recv_size = ring_buf_get(&this->m_ring_buf_ble, recv_buffer.getData(), recv_buffer.getSize());
             if (recv_size == 0) {
@@ -168,7 +165,6 @@ namespace Zephyr {
                 this->deallocate_out(0, recv_buffer);
             } else {
                 recv_buffer.setSize(recv_size);
-                LOG_INF("schedIn: %u bytes -> recv_out(0)", recv_size);
                 this->recv_out(0, recv_buffer, Drv::ByteStreamStatus::OP_OK);
             }
 
@@ -178,11 +174,6 @@ namespace Zephyr {
             }
 
         } else {
-            if (ring_buf_is_empty(&this->m_ring_buf_usb)) {
-                return; 
-            }
-
-            Fw::Buffer recv_buffer = this->allocate_out(0, SERIAL_BUFFER_SIZE);
             
             U32 recv_size = ring_buf_get(&this->m_ring_buf_usb, recv_buffer.getData(), recv_buffer.getSize());
             if (recv_size == 0) {
@@ -190,7 +181,6 @@ namespace Zephyr {
                 this->deallocate_out(0, recv_buffer);
             } else {
                 recv_buffer.setSize(recv_size);
-                LOG_INF("schedIn: %u bytes -> recv_out(0)", recv_size);
                 this->recv_out(0, recv_buffer, Drv::ByteStreamStatus::OP_OK);
             }
 

--- a/fprime-zephyr/Drv/ZephyrUartDriver/ZephyrUartDriver.cpp
+++ b/fprime-zephyr/Drv/ZephyrUartDriver/ZephyrUartDriver.cpp
@@ -11,6 +11,8 @@
 #include <Fw/FPrimeBasicTypes.hpp>
 #include <zephyr/logging/log.h>
 
+LOG_MODULE_REGISTER(ZephyrUartDriver, LOG_LEVEL_INF);
+
 namespace Zephyr {
 
     // ----------------------------------------------------------------------
@@ -33,7 +35,6 @@ namespace Zephyr {
     }
 
     void ZephyrUartDriver::configure(const struct device *bleDev, const struct device *usbDev, U32 baud_rate) {
-        LOG_ERR("Yay this log shows up");
         FW_ASSERT(bleDev != nullptr);
         FW_ASSERT(usbDev != nullptr);
         m_ble_dev = bleDev;
@@ -84,8 +85,9 @@ namespace Zephyr {
                 if (!self->m_rx_throttled_ble && uart_irq_rx_ready(dev)) {
                     int recv_len, rb_len;
                     uint8_t buffer[SERIAL_BUFFER_SIZE];
-                    size_t len = MIN(ring_buf_space_get(&self->m_ring_buf_ble),
-                            sizeof(buffer));
+
+                    // len = amount of space in the ring buffer
+                    size_t len = MIN(ring_buf_space_get(&self->m_ring_buf_ble), sizeof(buffer));
         
                     if (len == 0) {
                         /* Throttle because ring buffer is full */
@@ -94,12 +96,14 @@ namespace Zephyr {
                         continue;
                     }
         
+                    // recv_len = amount of bytes read from the UART FIFO
                     recv_len = uart_fifo_read(dev, buffer, len);
                     if (recv_len < 0) {
                         LOG_ERR("Failed to read UART FIFO");
                         recv_len = 0;
                     };
-        
+
+                    // rb_len = amount of bytes written to the ring buffer
                     rb_len = ring_buf_put(&self->m_ring_buf_ble, buffer, recv_len);
                     if (rb_len < recv_len) {
                         LOG_ERR("Drop %u bytes", recv_len - rb_len);
@@ -107,6 +111,7 @@ namespace Zephyr {
         
                     LOG_INF("IRQ rx: %d bytes -> ringbuf", rb_len);
 
+                    // update the last RX time for the BLE link
                     if (rb_len > 0) {
                         self->m_last_rx_ble_ms = k_uptime_get_32();
                     }
@@ -194,12 +199,10 @@ namespace Zephyr {
     Drv::ByteStreamStatus ZephyrUartDriver :: send_handler(const FwIndexType portNum, Fw::Buffer &sendBuffer) {
         ActiveUart active_uart = this->m_last_rx_ble_ms >= this->m_last_rx_usb_ms ? ActiveUart::BLE : ActiveUart::USB;
         if (active_uart == ActiveUart::BLE) {
-            LOG_INF("TX: %u bytes", (unsigned int)sendBuffer.getSize());
             for (U32 i = 0; i < sendBuffer.getSize(); i++) {
                 uart_poll_out(this->m_ble_dev, sendBuffer.getData()[i]);
             }
         } else {
-            LOG_INF("TX: %u bytes", (unsigned int)sendBuffer.getSize());
             for (U32 i = 0; i < sendBuffer.getSize(); i++) {
                 uart_poll_out(this->m_usb_dev, sendBuffer.getData()[i]);
             }
@@ -208,7 +211,6 @@ namespace Zephyr {
     }
 
     void ZephyrUartDriver ::recvReturnIn_handler(const FwIndexType portNum, Fw::Buffer &returnBuffer) {
-        LOG_INF("Buffer deallocated, size=%u", (unsigned int)returnBuffer.getSize());
         this->deallocate_out(0, returnBuffer);
     }
 

--- a/fprime-zephyr/Drv/ZephyrUartDriver/ZephyrUartDriver.cpp
+++ b/fprime-zephyr/Drv/ZephyrUartDriver/ZephyrUartDriver.cpp
@@ -10,6 +10,7 @@
 #include "Fw/Types/Assert.hpp"
 #include <Fw/FPrimeBasicTypes.hpp>
 #include <zephyr/logging/log.h>
+#include <zephyr/sys/printk.h>
 
 LOG_MODULE_REGISTER(ZephyrUartDriver, LOG_LEVEL_INF);
 
@@ -157,38 +158,37 @@ namespace Zephyr {
     // Handler implementations for user-defined typed input ports
     // ----------------------------------------------------------------------
 
-    void ZephyrUartDriver :: schedIn_handler(const FwIndexType portNum, U32 context) {
-
-        Fw::Buffer recv_buffer = this->allocate_out(0, SERIAL_BUFFER_SIZE);
-
-        ActiveUart active_uart = this->m_last_rx_ble_ms >= this->m_last_rx_usb_ms ? ActiveUart::BLE : ActiveUart::USB;
-        if (active_uart == ActiveUart::BLE) {
-
-            U32 recv_size = ring_buf_get(&this->m_ring_buf_ble, recv_buffer.getData(), recv_buffer.getSize());
-            if (recv_size == 0) {
-                // no data received, deallocate buffer
-                this->deallocate_out(0, recv_buffer);
+    void ZephyrUartDriver::schedIn_handler(const FwIndexType portNum, U32 context) {
+        // --- BLE ring ---
+        {
+            Fw::Buffer buf = this->allocate_out(0, SERIAL_BUFFER_SIZE);
+            U32 n = ring_buf_get(&this->m_ring_buf_ble, buf.getData(), buf.getSize());
+            if (n == 0) {
+                this->deallocate_out(0, buf);
             } else {
-                recv_buffer.setSize(recv_size);
-                this->recv_out(0, recv_buffer, Drv::ByteStreamStatus::OP_OK);
+                buf.setSize(n);
+                this->recv_out(0, buf, Drv::ByteStreamStatus::OP_OK);
+                printk("SCHED BLE rx=%u ble_ms=%u usb_ms=%u\n",
+                       n, m_last_rx_ble_ms, m_last_rx_usb_ms);
             }
-
             if (this->m_rx_throttled_ble) {
                 uart_irq_rx_enable(this->m_ble_dev);
                 this->m_rx_throttled_ble = false;
             }
-
-        } else {
-            
-            U32 recv_size = ring_buf_get(&this->m_ring_buf_usb, recv_buffer.getData(), recv_buffer.getSize());
-            if (recv_size == 0) {
-                // no data received, deallocate buffer
-                this->deallocate_out(0, recv_buffer);
+        }
+    
+        // --- USB ring ---
+        {
+            Fw::Buffer buf = this->allocate_out(0, SERIAL_BUFFER_SIZE);
+            U32 n = ring_buf_get(&this->m_ring_buf_usb, buf.getData(), buf.getSize());
+            if (n == 0) {
+                this->deallocate_out(0, buf);
             } else {
-                recv_buffer.setSize(recv_size);
-                this->recv_out(0, recv_buffer, Drv::ByteStreamStatus::OP_OK);
+                buf.setSize(n);
+                this->recv_out(0, buf, Drv::ByteStreamStatus::OP_OK);
+                printk("SCHED USB rx=%u ble_ms=%u usb_ms=%u\n",
+                       n, m_last_rx_ble_ms, m_last_rx_usb_ms);
             }
-
             if (this->m_rx_throttled_usb) {
                 uart_irq_rx_enable(this->m_usb_dev);
                 this->m_rx_throttled_usb = false;
@@ -198,6 +198,11 @@ namespace Zephyr {
 
     Drv::ByteStreamStatus ZephyrUartDriver :: send_handler(const FwIndexType portNum, Fw::Buffer &sendBuffer) {
         ActiveUart active_uart = this->m_last_rx_ble_ms >= this->m_last_rx_usb_ms ? ActiveUart::BLE : ActiveUart::USB;
+        printk("SEND act=%s ble_ms=%u usb_ms=%u sz=%u\n",
+            active_uart == ActiveUart::BLE ? "BLE" : "USB",
+            m_last_rx_ble_ms, m_last_rx_usb_ms,
+            static_cast<unsigned>(sendBuffer.getSize()));
+        
         if (active_uart == ActiveUart::BLE) {
             for (U32 i = 0; i < sendBuffer.getSize(); i++) {
                 uart_poll_out(this->m_ble_dev, sendBuffer.getData()[i]);

--- a/fprime-zephyr/Drv/ZephyrUartDriver/ZephyrUartDriver.cpp
+++ b/fprime-zephyr/Drv/ZephyrUartDriver/ZephyrUartDriver.cpp
@@ -20,10 +20,11 @@ namespace Zephyr {
     // ----------------------------------------------------------------------
 
     ZephyrUartDriver ::
-        ZephyrUartDriver(
-            const char *const compName
-        ) : ZephyrUartDriverComponentBase(compName), 
-        m_rx_throttled(false)
+        ZephyrUartDriver(const char *const compName) : ZephyrUartDriverComponentBase(compName), 
+        m_rx_throttled_ble(false),
+        m_rx_throttled_usb(false),
+        m_last_rx_ble_ms(0),
+        m_last_rx_usb_ms(0)
     {
     }
 
@@ -33,11 +34,17 @@ namespace Zephyr {
 
     }
 
-    void ZephyrUartDriver::configure(const struct device *dev, U32 baud_rate) {
-        FW_ASSERT(dev != nullptr);
-        m_dev = dev;
+    void ZephyrUartDriver::configure(const struct device *bleDev, const struct device *usbDev, U32 baud_rate) {
+        FW_ASSERT(bleDev != nullptr);
+        FW_ASSERT(usbDev != nullptr);
+        m_ble_dev = bleDev;
+        m_usb_dev = usbDev;
 
-        if (!device_is_ready(this->m_dev)) {
+        bool ble_ready = device_is_ready(this->m_ble_dev);
+        bool usb_ready = device_is_ready(this->m_usb_dev);
+
+        if (!ble_ready && !usb_ready) {
+            LOG_ERR("UART devices not ready");
             return;
         }
 
@@ -48,13 +55,21 @@ namespace Zephyr {
             .data_bits = UART_CFG_DATA_BITS_8,
             .flow_ctrl = UART_CFG_FLOW_CTRL_NONE,
         };
-        uart_configure(this->m_dev, &uart_cfg);
 
-        ring_buf_init(&this->m_ring_buf, RING_BUF_SIZE, this->m_ring_buf_data);
-        uart_irq_callback_user_data_set(this->m_dev, serial_cb, this);
-
-        uart_irq_rx_enable(this->m_dev);
-	    uart_irq_tx_disable(this->m_dev);
+        if (ble_ready) {
+            uart_configure(this->m_ble_dev, &uart_cfg);
+            ring_buf_init(&this->m_ring_buf_ble, RING_BUF_SIZE, this->m_ring_buf_ble_data);
+            uart_irq_callback_user_data_set(this->m_ble_dev, serial_cb, this);
+            uart_irq_rx_enable(this->m_ble_dev);
+            uart_irq_tx_disable(this->m_ble_dev);
+        }
+        if (usb_ready) {
+            uart_configure(this->m_usb_dev, &uart_cfg);
+            ring_buf_init(&this->m_ring_buf_usb, RING_BUF_SIZE, this->m_ring_buf_usb_data);
+            uart_irq_callback_user_data_set(this->m_usb_dev, serial_cb, this);
+            uart_irq_rx_enable(this->m_usb_dev);
+            uart_irq_tx_disable(this->m_usb_dev);
+        }
 
         if (this->isConnected_ready_OutputPort(0)) {
             this->ready_out(0);
@@ -66,31 +81,69 @@ namespace Zephyr {
         struct ZephyrUartDriver *self = reinterpret_cast<ZephyrUartDriver *>(user_data);
 
         while (uart_irq_update(dev) && uart_irq_is_pending(dev)) {
-            if (!self->m_rx_throttled && uart_irq_rx_ready(dev)) {
-                int recv_len, rb_len;
-                uint8_t buffer[SERIAL_BUFFER_SIZE];
-                size_t len = MIN(ring_buf_space_get(&self->m_ring_buf),
-                         sizeof(buffer));
-    
-                if (len == 0) {
-                    /* Throttle because ring buffer is full */
-                    uart_irq_rx_disable(dev);
-                    self->m_rx_throttled = true;
-                    continue;
+            if (dev == self->m_ble_dev) {
+                if (!self->m_rx_throttled_ble && uart_irq_rx_ready(dev)) {
+                    int recv_len, rb_len;
+                    uint8_t buffer[SERIAL_BUFFER_SIZE];
+                    size_t len = MIN(ring_buf_space_get(&self->m_ring_buf_ble),
+                            sizeof(buffer));
+        
+                    if (len == 0) {
+                        /* Throttle because ring buffer is full */
+                        uart_irq_rx_disable(dev);
+                        self->m_rx_throttled_ble = true;
+                        continue;
+                    }
+        
+                    recv_len = uart_fifo_read(dev, buffer, len);
+                    if (recv_len < 0) {
+                        LOG_ERR("Failed to read UART FIFO");
+                        recv_len = 0;
+                    };
+        
+                    rb_len = ring_buf_put(&self->m_ring_buf_ble, buffer, recv_len);
+                    if (rb_len < recv_len) {
+                        LOG_ERR("Drop %u bytes", recv_len - rb_len);
+                    }
+        
+                    LOG_INF("IRQ rx: %d bytes -> ringbuf", rb_len);
+
+                    if (rb_len > 0) {
+                        self->m_last_rx_ble_ms = k_uptime_get_32();
+                    }
                 }
-    
-                recv_len = uart_fifo_read(dev, buffer, len);
-                if (recv_len < 0) {
-                    LOG_ERR("Failed to read UART FIFO");
-                    recv_len = 0;
-                };
-    
-                rb_len = ring_buf_put(&self->m_ring_buf, buffer, recv_len);
-                if (rb_len < recv_len) {
-                    LOG_ERR("Drop %u bytes", recv_len - rb_len);
+                
+            } else if (dev == self->m_usb_dev) {
+
+                if (!self->m_rx_throttled_usb && uart_irq_rx_ready(dev)) {
+                    int recv_len, rb_len;
+                    uint8_t buffer[SERIAL_BUFFER_SIZE];
+                    size_t len = MIN(ring_buf_space_get(&self->m_ring_buf_usb),
+                            sizeof(buffer));
+        
+                    if (len == 0) {
+                        /* Throttle because ring buffer is full */
+                        uart_irq_rx_disable(dev);
+                        self->m_rx_throttled_usb = true;
+                        continue;
+                    }
+        
+                    recv_len = uart_fifo_read(dev, buffer, len);
+                    if (recv_len < 0) {
+                        LOG_ERR("Failed to read UART FIFO");
+                        recv_len = 0;
+                    };
+        
+                    rb_len = ring_buf_put(&self->m_ring_buf_usb, buffer, recv_len);
+                    if (rb_len < recv_len) {
+                        LOG_ERR("Drop %u bytes", recv_len - rb_len);
+                    }
+                    if (rb_len > 0) {
+                        self->m_last_rx_usb_ms = k_uptime_get_32();
+                    }
+        
+                    LOG_INF("IRQ rx: %d bytes -> ringbuf", rb_len);
                 }
-    
-                LOG_INF("IRQ rx: %d bytes -> ringbuf", rb_len);
             }
         }
     
@@ -100,41 +153,66 @@ namespace Zephyr {
     // Handler implementations for user-defined typed input ports
     // ----------------------------------------------------------------------
 
-    void ZephyrUartDriver ::
-        schedIn_handler(
-            const FwIndexType portNum,
-            U32 context
-        )
-    {
-        if (ring_buf_is_empty(&this->m_ring_buf)) {
-            return; 
-        }
-        Fw::Buffer recv_buffer = this->allocate_out(0, SERIAL_BUFFER_SIZE);
+    void ZephyrUartDriver :: schedIn_handler(const FwIndexType portNum, U32 context) {
+        ActiveUart active_uart = this->m_last_rx_ble_ms >= this->m_last_rx_usb_ms ? ActiveUart::BLE : ActiveUart::USB;
+        if (active_uart == ActiveUart::BLE) {
+            if (ring_buf_is_empty(&this->m_ring_buf_ble)) {
+                return; 
+            }
 
-        U32 recv_size = ring_buf_get(&this->m_ring_buf, recv_buffer.getData(), recv_buffer.getSize());
-        if (recv_size == 0) {
-            // No data received, deallocate buffer
-            this->deallocate_out(0, recv_buffer);
+            Fw::Buffer recv_buffer = this->allocate_out(0, SERIAL_BUFFER_SIZE);
+
+            U32 recv_size = ring_buf_get(&this->m_ring_buf_ble, recv_buffer.getData(), recv_buffer.getSize());
+            if (recv_size == 0) {
+                // no data received, deallocate buffer
+                this->deallocate_out(0, recv_buffer);
+            } else {
+                recv_buffer.setSize(recv_size);
+                LOG_INF("schedIn: %u bytes -> recv_out(0)", recv_size);
+                this->recv_out(0, recv_buffer, Drv::ByteStreamStatus::OP_OK);
+            }
+
+            if (this->m_rx_throttled_ble) {
+                uart_irq_rx_enable(this->m_ble_dev);
+                this->m_rx_throttled_ble = false;
+            }
+
         } else {
-            recv_buffer.setSize(recv_size);
-            LOG_INF("schedIn: %u bytes -> recv_out", recv_size);
-            recv_out(0, recv_buffer, Drv::ByteStreamStatus::OP_OK);
-        }
-        if (this->m_rx_throttled) {
-            uart_irq_rx_enable(this->m_dev);
-            this->m_rx_throttled = false;
+            if (ring_buf_is_empty(&this->m_ring_buf_usb)) {
+                return; 
+            }
+
+            Fw::Buffer recv_buffer = this->allocate_out(0, SERIAL_BUFFER_SIZE);
+            
+            U32 recv_size = ring_buf_get(&this->m_ring_buf_usb, recv_buffer.getData(), recv_buffer.getSize());
+            if (recv_size == 0) {
+                // no data received, deallocate buffer
+                this->deallocate_out(0, recv_buffer);
+            } else {
+                recv_buffer.setSize(recv_size);
+                LOG_INF("schedIn: %u bytes -> recv_out(0)", recv_size);
+                this->recv_out(0, recv_buffer, Drv::ByteStreamStatus::OP_OK);
+            }
+
+            if (this->m_rx_throttled_usb) {
+                uart_irq_rx_enable(this->m_usb_dev);
+                this->m_rx_throttled_usb = false;
+            }
         }
     }
 
-    Drv::ByteStreamStatus ZephyrUartDriver ::
-        send_handler(
-            const FwIndexType portNum,
-            Fw::Buffer &sendBuffer
-        )
-    {
-        LOG_INF("TX: %u bytes", (unsigned int)sendBuffer.getSize());
-        for (U32 i = 0; i < sendBuffer.getSize(); i++) {
-            uart_poll_out(this->m_dev, sendBuffer.getData()[i]);
+    Drv::ByteStreamStatus ZephyrUartDriver :: send_handler(const FwIndexType portNum, Fw::Buffer &sendBuffer) {
+        ActiveUart active_uart = this->m_last_rx_ble_ms >= this->m_last_rx_usb_ms ? ActiveUart::BLE : ActiveUart::USB;
+        if (active_uart == ActiveUart::BLE) {
+            LOG_INF("TX: %u bytes", (unsigned int)sendBuffer.getSize());
+            for (U32 i = 0; i < sendBuffer.getSize(); i++) {
+                uart_poll_out(this->m_ble_dev, sendBuffer.getData()[i]);
+            }
+        } else {
+            LOG_INF("TX: %u bytes", (unsigned int)sendBuffer.getSize());
+            for (U32 i = 0; i < sendBuffer.getSize(); i++) {
+                uart_poll_out(this->m_usb_dev, sendBuffer.getData()[i]);
+            }
         }
         return Drv::ByteStreamStatus::OP_OK;
     }

--- a/fprime-zephyr/Drv/ZephyrUartDriver/ZephyrUartDriver.hpp
+++ b/fprime-zephyr/Drv/ZephyrUartDriver/ZephyrUartDriver.hpp
@@ -14,7 +14,7 @@
 #include <zephyr/drivers/uart.h>
 #include <zephyr/sys/ring_buffer.h>
 
-#define RING_BUF_SIZE 1024
+#define RING_BUF_SIZE 4096
 
 namespace Zephyr {
 
@@ -22,7 +22,7 @@ namespace Zephyr {
     public ZephyrUartDriverComponentBase
   {
 
-    const FwSizeType SERIAL_BUFFER_SIZE = 64;
+    const FwSizeType SERIAL_BUFFER_SIZE = 512;
 
     public:
 

--- a/fprime-zephyr/Drv/ZephyrUartDriver/ZephyrUartDriver.hpp
+++ b/fprime-zephyr/Drv/ZephyrUartDriver/ZephyrUartDriver.hpp
@@ -14,7 +14,7 @@
 #include <zephyr/drivers/uart.h>
 #include <zephyr/sys/ring_buffer.h>
 
-#define RING_BUF_SIZE 4096
+#define RING_BUF_SIZE 1024
 
 namespace Zephyr {
 
@@ -22,7 +22,7 @@ namespace Zephyr {
     public ZephyrUartDriverComponentBase
   {
 
-    const FwSizeType SERIAL_BUFFER_SIZE = 512;
+    static constexpr FwSizeType SERIAL_BUFFER_SIZE = 64;
 
     public:
 
@@ -76,6 +76,7 @@ namespace Zephyr {
 
         U8 m_ring_buf_data[RING_BUF_SIZE];
         struct ring_buf m_ring_buf;
+        bool m_rx_throttled; 
     };
 
 } // end namespace Zephyr

--- a/fprime-zephyr/Drv/ZephyrUartDriver/ZephyrUartDriver.hpp
+++ b/fprime-zephyr/Drv/ZephyrUartDriver/ZephyrUartDriver.hpp
@@ -25,7 +25,7 @@ namespace Zephyr {
 
   class ZephyrUartDriver : public ZephyrUartDriverComponentBase {
 
-    static constexpr FwSizeType SERIAL_BUFFER_SIZE = 64;
+    const FwSizeType SERIAL_BUFFER_SIZE = 64;
 
     public:
 
@@ -75,7 +75,7 @@ namespace Zephyr {
             Fw::Buffer &returnBuffer
         );
 
-        /* separate ring buffers for BLE and USB because each link produces bytes independently on its own interrupt, keeping one shared ring buffer
+        /* separate ring buffers for BLE and USB because each link produces bytes independently on its own interrupt. Keeping one shared ring buffer
            for both makes the drain policy messier and it's harder to determine which link was the last to receive data (used to determine which link to send data to)
         */
         const struct device *m_ble_dev;

--- a/fprime-zephyr/Drv/ZephyrUartDriver/ZephyrUartDriver.hpp
+++ b/fprime-zephyr/Drv/ZephyrUartDriver/ZephyrUartDriver.hpp
@@ -16,11 +16,14 @@
 
 #define RING_BUF_SIZE 1024
 
+enum class ActiveUart {
+    BLE,
+    USB
+};
+
 namespace Zephyr {
 
-  class ZephyrUartDriver :
-    public ZephyrUartDriverComponentBase
-  {
+  class ZephyrUartDriver : public ZephyrUartDriverComponentBase {
 
     static constexpr FwSizeType SERIAL_BUFFER_SIZE = 64;
 
@@ -40,7 +43,7 @@ namespace Zephyr {
         //!
         ~ZephyrUartDriver();
 
-        void configure(const struct device *dev, U32 baud_rate);
+        void configure(const struct device *bleDev, const struct device *usbDev, U32 baud_rate);
 
     public:
 
@@ -72,11 +75,22 @@ namespace Zephyr {
             Fw::Buffer &returnBuffer
         );
 
-        const struct device *m_dev;
+        /* separate ring buffers for BLE and USB because each link produces bytes independently on its own interrupt, keeping one shared ring buffer
+           for both makes the drain policy messier and it's harder to determine which link was the last to receive data (used to determine which link to send data to)
+        */
+        const struct device *m_ble_dev;
+        U8 m_ring_buf_ble_data[RING_BUF_SIZE];
+        struct ring_buf m_ring_buf_ble;
+        bool m_rx_throttled_ble;
 
-        U8 m_ring_buf_data[RING_BUF_SIZE];
-        struct ring_buf m_ring_buf;
-        bool m_rx_throttled; 
+        const struct device *m_usb_dev;
+        U8 m_ring_buf_usb_data[RING_BUF_SIZE];
+        struct ring_buf m_ring_buf_usb;
+        bool m_rx_throttled_usb; 
+
+        /* used to determine which link received data last and therefore, which link to send data to */
+        U32 m_last_rx_ble_ms;
+        U32 m_last_rx_usb_ms;
     };
 
 } // end namespace Zephyr

--- a/fprime-zephyr/Drv/ZephyrUartDriver/ZephyrUartDriver.hpp
+++ b/fprime-zephyr/Drv/ZephyrUartDriver/ZephyrUartDriver.hpp
@@ -25,7 +25,7 @@ namespace Zephyr {
 
   class ZephyrUartDriver : public ZephyrUartDriverComponentBase {
 
-    const FwSizeType SERIAL_BUFFER_SIZE = 64;
+    static constexpr FwSizeType SERIAL_BUFFER_SIZE = 64;
 
     public:
 


### PR DESCRIPTION
## Description

Added dual support logic for Bluetooth (BLE) and USB. 2 separate ring buffers for two transport modes. Most recent RX timestamp determines which one is the active transport. Most functions have the same high-level logic but just branches off for Bluetooth-/USB-specific variables after determining which is the active transport. 

## Related Issues/Tickets
[ASCS-21](https://aspadeco.atlassian.net/browse/ASCS-21) Bluetooth

## How Has This Been Tested?

This firmware was tested with the code from the following branches: crkt-receiver ble-usb-dual support, lib/fprime-zephyr ble-usb-dual-support, pepper-android ble-usb-dual-support. 

- [ ] Unit tests
- [ ] Integration tests
- [ ] Z Tests
- [x] Manual testing:

1, Connect with Bluetooth, check detection packet transportation via detection screen in the app
2. Connect with USB, check detection packet transportation via detection screen in the app

## Screenshots / Recordings (if applicable)

## Checklist

- [ ] Written detailed documentation (i.e sdd, confluence page, etc.)
- [ ] Have written relevant integration tests and have documented them in the sdd
- [ ] Have done a code review with
- [ ] Have tested this PR on every supported board with correct board definitions

## Further Notes / Considerations