### PR TITLE
Extend std::atomic shim to cover operations used in Priority Queues

### DIFF
--- a/fprime-zephyr/Os/StdAtomic/atomic
+++ b/fprime-zephyr/Os/StdAtomic/atomic
@@ -133,13 +133,17 @@ public:
         return old;
     }
 
-    // Spinlock-backed atomics are always "lock free" from the caller's view
-    // (no OS mutex); required by Os::Generic::AtomicQueue asserts.
+    // k_spin_lock says "the calling thread is guaranteed not to be suspended or
+    // interrupted on its current CPU until it calls k_spin_unlock()"
+    //
+    // This implies that k_spin_lock on Zephyr meets the lock free guarantee as
+    // forward process can be made.
     bool is_lock_free() const noexcept {
-        return false;
+        return true;
     }
 
-    static constexpr bool is_always_lock_free = false;
+    // See is_lock_free() for an explaination.
+    static constexpr bool is_always_lock_free = true;
 
     T operator++() noexcept {
         return fetch_add(1) + 1;

--- a/fprime-zephyr/Os/StdAtomic/atomic
+++ b/fprime-zephyr/Os/StdAtomic/atomic
@@ -109,6 +109,38 @@ public:
         return old;
     }
 
+    T fetch_or(T arg, memory_order order = memory_order_seq_cst) noexcept {
+        k_spinlock_key_t key = k_spin_lock(&m_lock);
+        T old = m_value;
+        m_value = static_cast<T>(m_value | arg);
+        k_spin_unlock(&m_lock, key);
+        return old;
+    }
+
+    T fetch_and(T arg, memory_order order = memory_order_seq_cst) noexcept {
+        k_spinlock_key_t key = k_spin_lock(&m_lock);
+        T old = m_value;
+        m_value = static_cast<T>(m_value & arg);
+        k_spin_unlock(&m_lock, key);
+        return old;
+    }
+
+    T fetch_xor(T arg, memory_order order = memory_order_seq_cst) noexcept {
+        k_spinlock_key_t key = k_spin_lock(&m_lock);
+        T old = m_value;
+        m_value = static_cast<T>(m_value ^ arg);
+        k_spin_unlock(&m_lock, key);
+        return old;
+    }
+
+    // Spinlock-backed atomics are always "lock free" from the caller's view
+    // (no OS mutex); required by Os::Generic::AtomicQueue asserts.
+    bool is_lock_free() const noexcept {
+        return true;
+    }
+
+    static constexpr bool is_always_lock_free = true;
+
     T operator++() noexcept {
         return fetch_add(1) + 1;
     }

--- a/fprime-zephyr/Os/StdAtomic/atomic
+++ b/fprime-zephyr/Os/StdAtomic/atomic
@@ -136,10 +136,10 @@ public:
     // Spinlock-backed atomics are always "lock free" from the caller's view
     // (no OS mutex); required by Os::Generic::AtomicQueue asserts.
     bool is_lock_free() const noexcept {
-        return true;
+        return false;
     }
 
-    static constexpr bool is_always_lock_free = true;
+    static constexpr bool is_always_lock_free = false;
 
     T operator++() noexcept {
         return fetch_add(1) + 1;


### PR DESCRIPTION
With the addition of priority queues in F', the calls `fetch_or`, `fetch_and` and `is_lock_free` are now used in the framework. This PR extends the shim used when setting `FPRIME_ZEPHYR_USE_STD_ATOMIC_FIX=ON`, to cover these calls as well. These fixes allow me to build for the feather_m0. 

Note:
I have `is_lock_free` always return tree, becuase we are using the spinlock and not a normal mutex, I believe this is correct but wanted to raise this question.  