### PR TITLE
Update for nasa/fprime#5615: RawTimeInterface::getDelegate parameters modified 

### DIFF
--- a/fprime-zephyr/Os/DefaultRawTime.cpp
+++ b/fprime-zephyr/Os/DefaultRawTime.cpp
@@ -10,8 +10,12 @@ namespace Os {
 //! \brief get a delegate for RawTimeInterface that intercepts calls for Posix
 //! \param aligned_new_memory: aligned memory to fill
 //! \param to_copy: pointer to copy-constructor input
+//! \param source: timer source selection (unused in Zephyr - only RAWTIME_DEFAULT supported)
 //! \return: pointer to delegate
-RawTimeInterface *RawTimeInterface::getDelegate(RawTimeHandleStorage& aligned_new_memory, const RawTimeInterface* to_copy) {
+RawTimeInterface *RawTimeInterface::getDelegate(RawTimeHandleStorage& aligned_new_memory,
+                                                const RawTimeInterface* to_copy,
+                                                RawTimeSource source) {
+    (void)source;  // Zephyr implementation only supports default timer source
     return Os::Delegate::makeDelegate<RawTimeInterface, Os::Zephyr::RawTime::ZephyrRawTime, RawTimeHandleStorage>(
             aligned_new_memory, to_copy
     );

--- a/fprime-zephyr/Os/DefaultRawTime.cpp
+++ b/fprime-zephyr/Os/DefaultRawTime.cpp
@@ -15,7 +15,7 @@ namespace Os {
 RawTimeInterface *RawTimeInterface::getDelegate(RawTimeHandleStorage& aligned_new_memory,
                                                 const RawTimeInterface* to_copy,
                                                 RawTimeSource source) {
-    (void)source;  // Zephyr implementation only supports default timer source
+    FW_ASSERT(RawTimeSource::RAWTIME_DEFAULT == source, source);
     return Os::Delegate::makeDelegate<RawTimeInterface, Os::Zephyr::RawTime::ZephyrRawTime, RawTimeHandleStorage>(
             aligned_new_memory, to_copy
     );


### PR DESCRIPTION
In nasa/fprime#5615, the RawTimeInterface::getDelegate() function was changed to have three parameters. This PR updates zephyr to match 